### PR TITLE
Cleanup AWS CFN instructions to work with AWS CLI

### DIFF
--- a/AWS/README.md
+++ b/AWS/README.md
@@ -8,31 +8,49 @@ A Cloud Formation template for deploying Corelight Sensors.
 
 ## Dependencies
 
-* Install [Task][]
-
-[Task]: https://taskfile.dev/
+* Install [AWS Command Line Interface][awscli]
 
 ### Deployment Instructions
 
-Edit the vars section of the `Taskfile.yml` file with your cloud environment's
-configuration.
+Execute the following commands making sure to provide the appropriate
+parameters for your environment.
 
 #### Sensor
 
 Create a new stack:
 
-    $ task cfn:sensor:create
+```bash
+aws cloudformation create-stack --region {{.AWS_REGION}} \
+  --stack-name corelight-sensor \
+  --parameters \
+    ParameterKey=DeploymentName,ParameterValue={{.SENSOR_DEPLOYMENT_NAME}} \
+    ParameterKey=AutoScalingAvailabilityZones,ParameterValue={{.SENSOR_AUTO_SCALING_AVAILABILITY_ZONES}} \
+    ParameterKey=ImageId,ParameterValue={{.SENSOR_IMAGE_ID}} \
+    ParameterKey=VpcId,ParameterValue={{.SENSOR_VPC_ID}} \
+    ParameterKey=MonitoringSubnetId,ParameterValue={{.SENSOR_MONITORING_SUBNET_ID}} \
+    ParameterKey=MonitoringSubnetCIDR,ParameterValue={{.SENSOR_MONITORING_SUBNET_CIDR}} \
+    ParameterKey=ManagementSubnetId,ParameterValue={{.SENSOR_MANAGEMENT_SUBNET_ID}} \
+    ParameterKey=ManagementSubnetCIDR,ParameterValue={{.SENSOR_MANAGEMENT_SUBNET_CIDR}} \
+    ParameterKey=KeyPairName,ParameterValue={{.SENSOR_KEY_PAIR_NAME}} \
+  --template-body file://cfn.yaml
+```
 
 Update existing stack:
 
-    $ task cfn:sensor:update
+```bash
+aws cloudformation update-stack --region {{.AWS_REGION}} \
+  --stack-name corelight-sensor \
+  --parameters \
+    ParameterKey=DeploymentName,ParameterValue={{.SENSOR_DEPLOYMENT_NAME}} \
+    ParameterKey=AutoScalingAvailabilityZones,ParameterValue={{.SENSOR_AUTO_SCALING_AVAILABILITY_ZONES}} \
+    ParameterKey=ImageId,ParameterValue={{.SENSOR_IMAGE_ID}} \
+    ParameterKey=VpcId,ParameterValue={{.SENSOR_VPC_ID}} \
+    ParameterKey=MonitoringSubnetId,ParameterValue={{.SENSOR_MONITORING_SUBNET_ID}} \
+    ParameterKey=MonitoringSubnetCIDR,ParameterValue={{.SENSOR_MONITORING_SUBNET_CIDR}} \
+    ParameterKey=ManagementSubnetId,ParameterValue={{.SENSOR_MANAGEMENT_SUBNET_ID}} \
+    ParameterKey=ManagementSubnetCIDR,ParameterValue={{.SENSOR_MANAGEMENT_SUBNET_CIDR}} \
+    ParameterKey=KeyPairName,ParameterValue={{.SENSOR_KEY_PAIR_NAME}} \
+  --template-body file://cfn.yaml
+```
 
-## Testing
-
-Execute tests:
-
-    $ task test
-
-List helpful targets:
-
-    $ task
+[awscli]: https://aws.amazon.com/cli/

--- a/AWS/README.md
+++ b/AWS/README.md
@@ -20,36 +20,36 @@ parameters for your environment.
 Create a new stack:
 
 ```bash
-aws cloudformation create-stack --region {{.AWS_REGION}} \
+aws cloudformation create-stack --region <AWS_REGION> \
   --stack-name corelight-sensor \
   --parameters \
-    ParameterKey=DeploymentName,ParameterValue={{.SENSOR_DEPLOYMENT_NAME}} \
-    ParameterKey=AutoScalingAvailabilityZones,ParameterValue={{.SENSOR_AUTO_SCALING_AVAILABILITY_ZONES}} \
-    ParameterKey=ImageId,ParameterValue={{.SENSOR_IMAGE_ID}} \
-    ParameterKey=VpcId,ParameterValue={{.SENSOR_VPC_ID}} \
-    ParameterKey=MonitoringSubnetId,ParameterValue={{.SENSOR_MONITORING_SUBNET_ID}} \
-    ParameterKey=MonitoringSubnetCIDR,ParameterValue={{.SENSOR_MONITORING_SUBNET_CIDR}} \
-    ParameterKey=ManagementSubnetId,ParameterValue={{.SENSOR_MANAGEMENT_SUBNET_ID}} \
-    ParameterKey=ManagementSubnetCIDR,ParameterValue={{.SENSOR_MANAGEMENT_SUBNET_CIDR}} \
-    ParameterKey=KeyPairName,ParameterValue={{.SENSOR_KEY_PAIR_NAME}} \
+    ParameterKey=DeploymentName,ParameterValue=<SENSOR_DEPLOYMENT_NAME> \
+    ParameterKey=AutoScalingAvailabilityZones,ParameterValue=<SENSOR_AUTO_SCALING_AVAILABILITY_ZONES> \
+    ParameterKey=ImageId,ParameterValue=<SENSOR_IMAGE_ID> \
+    ParameterKey=VpcId,ParameterValue=<SENSOR_VPC_ID> \
+    ParameterKey=MonitoringSubnetId,ParameterValue=<SENSOR_MONITORING_SUBNET_ID> \
+    ParameterKey=MonitoringSubnetCIDR,ParameterValue=<SENSOR_MONITORING_SUBNET_CIDR> \
+    ParameterKey=ManagementSubnetId,ParameterValue=<SENSOR_MANAGEMENT_SUBNET_ID> \
+    ParameterKey=ManagementSubnetCIDR,ParameterValue=<SENSOR_MANAGEMENT_SUBNET_CIDR> \
+    ParameterKey=KeyPairName,ParameterValue=<SENSOR_KEY_PAIR_NAME> \
   --template-body file://cfn.yaml
 ```
 
 Update existing stack:
 
 ```bash
-aws cloudformation update-stack --region {{.AWS_REGION}} \
+aws cloudformation update-stack --region <AWS_REGION> \
   --stack-name corelight-sensor \
   --parameters \
-    ParameterKey=DeploymentName,ParameterValue={{.SENSOR_DEPLOYMENT_NAME}} \
-    ParameterKey=AutoScalingAvailabilityZones,ParameterValue={{.SENSOR_AUTO_SCALING_AVAILABILITY_ZONES}} \
-    ParameterKey=ImageId,ParameterValue={{.SENSOR_IMAGE_ID}} \
-    ParameterKey=VpcId,ParameterValue={{.SENSOR_VPC_ID}} \
-    ParameterKey=MonitoringSubnetId,ParameterValue={{.SENSOR_MONITORING_SUBNET_ID}} \
-    ParameterKey=MonitoringSubnetCIDR,ParameterValue={{.SENSOR_MONITORING_SUBNET_CIDR}} \
-    ParameterKey=ManagementSubnetId,ParameterValue={{.SENSOR_MANAGEMENT_SUBNET_ID}} \
-    ParameterKey=ManagementSubnetCIDR,ParameterValue={{.SENSOR_MANAGEMENT_SUBNET_CIDR}} \
-    ParameterKey=KeyPairName,ParameterValue={{.SENSOR_KEY_PAIR_NAME}} \
+    ParameterKey=DeploymentName,ParameterValue=<SENSOR_DEPLOYMENT_NAME> \
+    ParameterKey=AutoScalingAvailabilityZones,ParameterValue=<SENSOR_AUTO_SCALING_AVAILABILITY_ZONES> \
+    ParameterKey=ImageId,ParameterValue=<SENSOR_IMAGE_ID> \
+    ParameterKey=VpcId,ParameterValue=<SENSOR_VPC_ID> \
+    ParameterKey=MonitoringSubnetId,ParameterValue=<SENSOR_MONITORING_SUBNET_ID> \
+    ParameterKey=MonitoringSubnetCIDR,ParameterValue=<SENSOR_MONITORING_SUBNET_CIDR> \
+    ParameterKey=ManagementSubnetId,ParameterValue=<SENSOR_MANAGEMENT_SUBNET_ID> \
+    ParameterKey=ManagementSubnetCIDR,ParameterValue=<SENSOR_MANAGEMENT_SUBNET_CIDR> \
+    ParameterKey=KeyPairName,ParameterValue=<SENSOR_KEY_PAIR_NAME> \
   --template-body file://cfn.yaml
 ```
 


### PR DESCRIPTION
Cleaned up the AWS Cloud formation instructions to use the AWS CLI vs additional Task dependencies.